### PR TITLE
extract mesh at checkpointed iteration

### DIFF
--- a/imaginaire/trainers/base.py
+++ b/imaginaire/trainers/base.py
@@ -628,13 +628,9 @@ class Checkpointer(object):
             # Load the state dicts.
             print('- Loading the model...')
             self.model.load_state_dict(state_dict['model'], strict=self.strict_resume)
+            self.resume_epoch = state_dict['epoch']
+            self.resume_iteration = state_dict['iteration']
             if resume:
-                try:
-                    self.resume_epoch = state_dict['epoch']
-                    self.resume_iteration = state_dict['iteration']
-                except Exception:  # TODO: for backward compatibility, should be removed eventually.
-                    self.resume_epoch = state_dict['current_epoch']
-                    self.resume_iteration = state_dict['current_iteration']
                 self.sched.last_epoch = self.resume_iteration if self.iteration_mode else self.resume_epoch
                 if load_opt:
                     print('- Loading the optimizer...')

--- a/projects/neuralangelo/scripts/extract_mesh.py
+++ b/projects/neuralangelo/scripts/extract_mesh.py
@@ -65,7 +65,7 @@ def main():
     trainer.model.eval()
 
     # Set the coarse-to-fine levels.
-    trainer.current_iteration = cfg.max_iter
+    trainer.current_iteration = trainer.checkpointer.resume_iteration
     if cfg.model.object.sdf.encoding.coarse2fine.enabled:
         trainer.model_module.neural_sdf.set_active_levels(trainer.current_iteration)
         if cfg.model.object.sdf.gradient.mode == "numerical":


### PR DESCRIPTION
The iteration number in `projects/neuralangelo/scripts/extract_mesh.py` should be set corresponding to the checkpointed iteration number, in order for the coarse-to-fine hashgrid levels to be masked properly. This could especially affect checkpoints at earlier iterations. cc @mli0603 