### PR TITLE
Update toy example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,12 +30,13 @@ scripts/wandb/_staff/
 *.pkl
 *.pt
 *.bin
+*.ply
 
 # log folder
 logs/
 
 # dataset folder
-datasets/
+/datasets/
 
 # config folder
 !projects/neuralangelo/configs/custom/template.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ checkpoints
 # Credential information that should never be checked in
 *.secret
 
-scripts/wandb/_staff/
-
 # Data types
 *.png
 *.hdr
@@ -36,6 +34,7 @@ scripts/wandb/_staff/
 logs/
 
 # dataset folder
+datasets/
 /datasets/
 
 # config folder

--- a/DATA_PROCESSING.md
+++ b/DATA_PROCESSING.md
@@ -19,7 +19,7 @@ You can run the following command to preprocess your data:
 ```bash
 EXPERIMENT_NAME=toy_example
 PATH_TO_VIDEO=toy_example.MOV
-SKIP_FRAME_RATE=24
+SKIP_FRAME_RATE=4  # If video motion is small, set this to large values (e.g., 24). If video motion is large, set this to small values (e.g., 4).
 SCENE_TYPE=object  # {outdoor,indoor,object}
 bash projects/neuralangelo/scripts/preprocess.sh ${EXPERIMENT_NAME} ${PATH_TO_VIDEO} ${SKIP_FRAME_RATE} ${SCENE_TYPE}
 ```
@@ -30,7 +30,7 @@ Alternatively, you can follow the steps below if you want more fine-grained cont
 
     ```bash
     PATH_TO_VIDEO=toy_example.MOV
-    SKIP_FRAME_RATE=30
+    SKIP_FRAME_RATE=4  # If video motion is small, set this to large values (e.g., 24). If video motion is large, set this to small values (e.g., 4).
     bash projects/neuralangelo/scripts/run_ffmpeg.sh ${PATH_TO_VIDEO} ${SKIP_FRAME_RATE}
     ```
     `PATH_TO_VIDEO`: path to video  
@@ -39,7 +39,7 @@ Alternatively, you can follow the steps below if you want more fine-grained cont
 2. Run COLMAP
 
     ```bash
-    PATH_TO_IMAGES=toy_example_skip30
+    PATH_TO_IMAGES=datasets/toy_example_skip4
     bash projects/neuralangelo/scripts/run_colmap.sh ${PATH_TO_IMAGES}
     ```
     `PATH_TO_IMAGES`: path to extracted images
@@ -61,7 +61,7 @@ Alternatively, you can follow the steps below if you want more fine-grained cont
     In this step, we define the bounding region for reconstruction and convert the COLMAP data to json format following Instant NGP. We strongly recommend you go to step 5 to validate the quality of the automatic bounding region extraction for improved performance.
 
     ```bash
-    PATH_TO_IMAGES=toy_example_skip30
+    PATH_TO_IMAGES=datasets/toy_example_skip4
     SCENE_TYPE=object  # {outdoor,indoor,object}
     python3 projects/neuralangelo/scripts/convert_data_to_json.py --data_dir ${PATH_TO_IMAGES}/dense --scene_type ${SCENE_TYPE}
     ```
@@ -73,7 +73,7 @@ Alternatively, you can follow the steps below if you want more fine-grained cont
     ```bash
     EXPERIMENT_NAME=toy_example
     SCENE_TYPE=object  # {outdoor,indoor,object}
-    python3 projects/neuralangelo/scripts/generate_config.py --experiment_name ${EXPERIMENT_NAME} --data_dir ${PATH_TO_IMAGES}/dense --scene_type ${SCENE_TYPE} --auto_exposure_wb
+    python3 projects/neuralangelo/scripts/generate_config.py --experiment_name ${EXPERIMENT_NAME} --data_dir ${PATH_TO_IMAGES}/dense --scene_type ${SCENE_TYPE}
     ```
     The config file will be generated as `projects/neuralangelo/configs/custom/{EXPERIMENT_NAME}.yaml`.
 
@@ -85,13 +85,13 @@ Alternatively, you can follow the steps below if you want more fine-grained cont
 
 ### Inspect and adjust COLMAP results
 
-For certain cases, the camera poses estimated by COLMAP could be erroneous. In addition, the automated estimation of the bounding sphere could be inaccurate (which ideally should include the scene/object of interest).
+For certain cases, the camera poses estimated by COLMAP could be erroneous. In addition, the automated estimation of the bounding sphere could be inaccurate (which ideally should include the scene/object of interest). It is highly recommended that the bounding sphere is adjusted. 
 We offer some tools to to inspect and adjust the pre-processing results. Below are some options:
 
-- Blender: Download [Blender](https://www.blender.org/download/) and follow the instructions in our [add-on repo](https://github.com/mli0603/BlenderNeuralangelo).
-- This [Jupyter notebook](projects/neuralangelo/scripts/visualize_colmap.ipynb) (using K3D) can be helpful for visualizing the COLMAP results.
+- Blender: Download [Blender](https://www.blender.org/download/) and follow the instructions in our [add-on repo](https://github.com/mli0603/BlenderNeuralangelo). The add-on will save your adjustment of the bounding sphere.
+- This [Jupyter notebook](projects/neuralangelo/scripts/visualize_colmap.ipynb) (using K3D) can be helpful for visualizing the COLMAP results. You can adjust the bounding sphere by manually specifying the refining sphere center and size in the `data.readjust` config.
 
-It is highly recommended that the bounding sphere is adjusted. You can do so by manually specifying the refining sphere center and size in the `data.readjust` config.
+If a continous camera recording trajectory turns into broken trajectories, it is because COLMAP fails due to ambiguous matches. You can try to change `exhaustive_matcher` to `sequential_matcher` in [run_colmap.sh file](https://github.com/NVlabs/neuralangelo/blob/main/projects/neuralangelo/scripts/run_colmap.sh#L24).
 
 ## DTU dataset
 - Please use respecting the license terms of the dataset.

--- a/DATA_PROCESSING.md
+++ b/DATA_PROCESSING.md
@@ -1,5 +1,7 @@
 # Data Preparation
 
+*Note: please use respecting the license terms of each dataset. Each user is responsible for checking the content of datasets and the applicable licenses and determining if suitable for the intended use.*
+
 The following sections provide a step-by-step guide on how to convert a video to a json file that Neuralangelo parses.
 
 ## Prerequisites
@@ -9,7 +11,7 @@ git submodule update --init --recursive
 ```
 
 ## Self-captured video sequence
-To capture your own data, we recommend using a high shutter speed to avoid motion blur (which is very common when using a phone camera). We provide a synthetic [Lego sequence](https://drive.google.com/file/d/1yWoZ4Hk3FgmV3pd34ZbW7jEqgqyJgzHy/view?usp=drive_link) (from the original NeRF) as a toy example video for testing the workflow. There are two steps:
+To capture your own data, we recommend using a high shutter speed to avoid motion blur (which is very common when using a phone camera). We provide a synthetic [Lego sequence](https://drive.google.com/file/d/1yWoZ4Hk3FgmV3pd34ZbW7jEqgqyJgzHy/view?usp=drive_link) (from the original [NeRF](https://github.com/bmild/nerf)) as a toy example video for testing the workflow. There are two steps:
 1. [preprocessing](#preprocessing) the data and running COLMAP,
 2. [inspecting](#inspect-and-adjust-colmap-results) and refining the bounding sphere of interest for running Neuralangelo.
 
@@ -97,8 +99,6 @@ However, this would take more time to process and could sometimes result in "bro
 For more details, please refer to the COLMAP [documentation](https://colmap.github.io/).
 
 ## DTU dataset
-- Please use respecting the license terms of the dataset.
-
 You can run the following command to download [the DTU dataset](https://roboimagedata.compute.dtu.dk/?page_id=36) that is preprocessed by NeuS authors and generate json files:
 ```bash
 PATH_TO_DTU=datasets/dtu  # Modify this to be the DTU dataset root directory.
@@ -106,8 +106,6 @@ bash projects/neuralangelo/scripts/preprocess_dtu.sh ${PATH_TO_DTU}
 ```
 
 ## Tanks and Temples dataset
-- Please use respecting the license terms of the dataset.
-
 Download the data from [Tanks and Temples](https://tanksandtemples.org/download/) website.
 You will also need to download additional [COLMAP/camera/alignment](https://drive.google.com/file/d/1jAr3IDvhVmmYeDWi0D_JfgiHcl70rzVE/view?resourcekey=) and the images of each scene.  
 The file structure should look like (you may need to move around the downloaded images):

--- a/DATA_PROCESSING.md
+++ b/DATA_PROCESSING.md
@@ -9,7 +9,7 @@ git submodule update --init --recursive
 ```
 
 ## Self-captured video sequence
-To capture your own data, we recommend using a high shutter speed to avoid motion blur (which is very common when using a phone camera). A [toy example](https://drive.google.com/file/d/1VJeWYNJEBK0MFIzHjI8xZzwf3_I3eLwH/view?usp=drive_link) is provided for testing the workflow. There are two steps:
+To capture your own data, we recommend using a high shutter speed to avoid motion blur (which is very common when using a phone camera). We provide a synthetic [Lego sequence](https://drive.google.com/file/d/1yWoZ4Hk3FgmV3pd34ZbW7jEqgqyJgzHy/view?usp=drive_link) (from the original NeRF) as a toy example video for testing the workflow. There are two steps:
 1. [preprocessing](#preprocessing) the data and running COLMAP,
 2. [inspecting](#inspect-and-adjust-colmap-results) and refining the bounding sphere of interest for running Neuralangelo.
 
@@ -17,11 +17,11 @@ To capture your own data, we recommend using a high shutter speed to avoid motio
 You can run the following command to preprocess your data:
 
 ```bash
-EXPERIMENT_NAME=toy_example
-PATH_TO_VIDEO=toy_example.MOV
-SKIP_FRAME_RATE=4  # If video motion is small, set this to large values (e.g., 24). If video motion is large, set this to small values (e.g., 4).
+EXPERIMENT=lego
+PATH_TO_VIDEO=lego.mp4
+SKIP_FRAME_RATE=2  # Set this to a larger value (e.g. 24) for small video motions and smaller value (e.g.) for large video motions.
 SCENE_TYPE=object  # {outdoor,indoor,object}
-bash projects/neuralangelo/scripts/preprocess.sh ${EXPERIMENT_NAME} ${PATH_TO_VIDEO} ${SKIP_FRAME_RATE} ${SCENE_TYPE}
+bash projects/neuralangelo/scripts/preprocess.sh ${EXPERIMENT} ${PATH_TO_VIDEO} ${SKIP_FRAME_RATE} ${SCENE_TYPE}
 ```
 
 Alternatively, you can follow the steps below if you want more fine-grained control.
@@ -29,8 +29,8 @@ Alternatively, you can follow the steps below if you want more fine-grained cont
 1. Convert video to images
 
     ```bash
-    PATH_TO_VIDEO=toy_example.MOV
-    SKIP_FRAME_RATE=4  # If video motion is small, set this to large values (e.g., 24). If video motion is large, set this to small values (e.g., 4).
+    PATH_TO_VIDEO=lego.mp4
+    SKIP_FRAME_RATE=2  # Set this to a larger value (e.g. 24) for small video motions and smaller value (e.g.) for large video motions.
     bash projects/neuralangelo/scripts/run_ffmpeg.sh ${PATH_TO_VIDEO} ${SKIP_FRAME_RATE}
     ```
     `PATH_TO_VIDEO`: path to video  
@@ -39,7 +39,7 @@ Alternatively, you can follow the steps below if you want more fine-grained cont
 2. Run COLMAP
 
     ```bash
-    PATH_TO_IMAGES=datasets/toy_example_skip4
+    PATH_TO_IMAGES=datasets/lego_skip2
     bash projects/neuralangelo/scripts/run_colmap.sh ${PATH_TO_IMAGES}
     ```
     `PATH_TO_IMAGES`: path to extracted images
@@ -61,7 +61,7 @@ Alternatively, you can follow the steps below if you want more fine-grained cont
     In this step, we define the bounding region for reconstruction and convert the COLMAP data to json format following Instant NGP. We strongly recommend you go to step 5 to validate the quality of the automatic bounding region extraction for improved performance.
 
     ```bash
-    PATH_TO_IMAGES=datasets/toy_example_skip4
+    PATH_TO_IMAGES=datasets/lego_skip2
     SCENE_TYPE=object  # {outdoor,indoor,object}
     python3 projects/neuralangelo/scripts/convert_data_to_json.py --data_dir ${PATH_TO_IMAGES}/dense --scene_type ${SCENE_TYPE}
     ```
@@ -71,11 +71,11 @@ Alternatively, you can follow the steps below if you want more fine-grained cont
 
     Use the following to configure and generate your config files
     ```bash
-    EXPERIMENT_NAME=toy_example
+    EXPERIMENT=lego
     SCENE_TYPE=object  # {outdoor,indoor,object}
-    python3 projects/neuralangelo/scripts/generate_config.py --experiment_name ${EXPERIMENT_NAME} --data_dir ${PATH_TO_IMAGES}/dense --scene_type ${SCENE_TYPE}
+    python3 projects/neuralangelo/scripts/generate_config.py --experiment_name ${EXPERIMENT} --data_dir ${PATH_TO_IMAGES}/dense --scene_type ${SCENE_TYPE}
     ```
-    The config file will be generated as `projects/neuralangelo/configs/custom/{EXPERIMENT_NAME}.yaml`.
+    The config file will be generated as `projects/neuralangelo/configs/custom/{EXPERIMENT}.yaml`.
 
     To find more arguments and how they work:
     ```bash
@@ -91,7 +91,10 @@ We offer some tools to to inspect and adjust the pre-processing results. Below a
 - Blender: Download [Blender](https://www.blender.org/download/) and follow the instructions in our [add-on repo](https://github.com/mli0603/BlenderNeuralangelo). The add-on will save your adjustment of the bounding sphere.
 - This [Jupyter notebook](projects/neuralangelo/scripts/visualize_colmap.ipynb) (using K3D) can be helpful for visualizing the COLMAP results. You can adjust the bounding sphere by manually specifying the refining sphere center and size in the `data.readjust` config.
 
-If a continous camera recording trajectory turns into broken trajectories, it is because COLMAP fails due to ambiguous matches. You can try to change `exhaustive_matcher` to `sequential_matcher` in [run_colmap.sh file](https://github.com/NVlabs/neuralangelo/blob/main/projects/neuralangelo/scripts/run_colmap.sh#L24).
+For certain cases, an exhaustive feature matcher may be able to estimate more accurate camera poses.
+This could be done by changing `sequential_matcher` to `exhaustive_matcher` in [run_colmap.sh](https://github.com/NVlabs/neuralangelo/blob/main/projects/neuralangelo/scripts/run_colmap.sh#L24).
+However, this would take more time to process and could sometimes result in "broken trajectories" (from COLMAP failing due to ambiguous matches).
+For more details, please refer to the COLMAP [documentation](https://colmap.github.io/).
 
 ## DTU dataset
 - Please use respecting the license terms of the dataset.

--- a/projects/neuralangelo/scripts/preprocess.sh
+++ b/projects/neuralangelo/scripts/preprocess.sh
@@ -9,7 +9,8 @@
 # -----------------------------------------------------------------------------
 
 # {experiment_name} {path_to_video} {skip_frame_rate} {scene_type}
-image_path=datasets/${2%.*}_skip${3}
+base_name=$(basename ${2})
+image_path=datasets/${base_name%.*}_skip${3}
 bash projects/neuralangelo/scripts/run_ffmpeg.sh ${2} ${3}
 bash projects/neuralangelo/scripts/run_colmap.sh ${image_path}
 python3 projects/neuralangelo/scripts/convert_data_to_json.py --data_dir ${image_path}/dense --scene_type ${4}

--- a/projects/neuralangelo/scripts/run_colmap.sh
+++ b/projects/neuralangelo/scripts/run_colmap.sh
@@ -21,7 +21,7 @@ colmap feature_extractor \
     --SiftExtraction.num_threads=32 \
     --ImageReader.single_camera=true # assuming single camera
 
-colmap exhaustive_matcher \
+colmap sequential_matcher \
     --database_path ${1}/database.db \
     --SiftMatching.use_gpu=true
 

--- a/projects/neuralangelo/scripts/run_colmap.sh
+++ b/projects/neuralangelo/scripts/run_colmap.sh
@@ -21,7 +21,7 @@ colmap feature_extractor \
     --SiftExtraction.num_threads=32 \
     --ImageReader.single_camera=true # assuming single camera
 
-colmap sequential_matcher \
+colmap exhaustive_matcher \
     --database_path ${1}/database.db \
     --SiftMatching.use_gpu=true
 

--- a/projects/neuralangelo/scripts/run_ffmpeg.sh
+++ b/projects/neuralangelo/scripts/run_ffmpeg.sh
@@ -10,6 +10,7 @@
 
 # usage: run_ffmpeg.sh <full_fname.mp4> <skip_frames>
 
-image_path=datasets/${1%.*}_skip${2}/raw_images
+base_name=$(basename ${1})
+image_path=datasets/${base_name%.*}_skip${2}/raw_images
 mkdir -p ${image_path}
 ffmpeg -i $1 -vf "select=not(mod(n\,$2))" -vsync vfr -q:v 2 ${image_path}/%06d.jpg


### PR DESCRIPTION
Toy example and data preprocessing document are updated to guide users to try Neuralangelo.

- Update toy example to lego sequence.
- Added explanation on colmap feature matchers in data preprocessing readme. 
- Support full system file path and generate dataset under the folder `datasets`
- Ignore `.ply` files 