### PR TITLE
Create enclosing folder on mesh export if it does not already exit

### DIFF
--- a/projects/neuralangelo/scripts/extract_mesh.py
+++ b/projects/neuralangelo/scripts/extract_mesh.py
@@ -16,7 +16,6 @@ import os
 import sys
 import numpy as np
 from functools import partial
-from pathlib import Path
 
 sys.path.append(os.getcwd())
 from imaginaire.config import Config, recursive_update_strict, parse_cmdline_arguments  # noqa: E402
@@ -98,9 +97,7 @@ def main():
         # center and scale
         mesh.vertices = mesh.vertices * meta["sphere_radius"] + np.array(meta["sphere_center"])
         mesh.update_faces(mesh.nondegenerate_faces())
-        folderpath = Path(args.output_file).parent
-        if not folderpath.exists():
-            folderpath.mkdir(parents=True)
+        os.makedirs(os.path.dirname(args.output_file), exist_ok=True)
         mesh.export(args.output_file)
 
 

--- a/projects/neuralangelo/scripts/extract_mesh.py
+++ b/projects/neuralangelo/scripts/extract_mesh.py
@@ -16,6 +16,7 @@ import os
 import sys
 import numpy as np
 from functools import partial
+from pathlib import Path
 
 sys.path.append(os.getcwd())
 from imaginaire.config import Config, recursive_update_strict, parse_cmdline_arguments  # noqa: E402
@@ -97,6 +98,9 @@ def main():
         # center and scale
         mesh.vertices = mesh.vertices * meta["sphere_radius"] + np.array(meta["sphere_center"])
         mesh.update_faces(mesh.nondegenerate_faces())
+        folderpath = Path(args.output_file).parent
+        if not folderpath.exists():
+            folderpath.mkdir(parents=True)
         mesh.export(args.output_file)
 
 


### PR DESCRIPTION
Currently, when trying to export a mesh, neuralangelo will crash if the path to the designated output file does not already exist. I think it's in most users intentions to have that path created on the spot, otherwise it wouldn't have been specified like that.

This change adds a check that creates parent folders if they are not already there to prevent that crash. It's a very minor conveniece change.

Feel free to do adjust or do whatever with this pull request, and thank you for the repo!

